### PR TITLE
Suppress Coverity USE_AFTER_FREE false positives

### DIFF
--- a/coverity/model_file
+++ b/coverity/model_file
@@ -18,3 +18,15 @@ void Must(bool condition) {
 void exit(int result) {
         __coverity_panic__();
 }
+
+namespace __coverity_template__
+{
+
+class RefCount
+{
+    void dereference(void const *newP = nullptr) { p_ = newP; }
+    void reference(const RefCount& ) {}
+    void const *p_;
+};
+
+}


### PR DESCRIPTION
Symptoms from the Coverity defects report:

    CID 1490851: Memory - corruptions (USE_AFTER_FREE)
    Calling "~RefCount" frees pointer "callback.p_" which has already
    been freed.

The general scenario leading to this problem is the following:

* A local RefCount object is created.

* The object copy is passed to another method. Coverity incorrectly
  assumes that this copy, when it is destructed, also deletes the
  underlying object.

* When the local RefCount object is destructed, Coverity concludes
  that the underlying object has been already deleted.

We did many experiments and came to a conclusion that Coverity cannot
properly track ref-counting in RefCount and Lock classes. In fact,
it makes the false assumption that a single Lock::unlock() of the
RefCount copy (with Lock::count_==2) can make this counter zero.
It looks like that Coverity simply does not enter Lock::unlock()
but rather treats it as a 'black box' and expects it returning
any result, regardless of the context.

We considered two approaches, implementing the second one:

1. Adjust Squid code to overcome this specific Coverity flaw.
   For example, we could adjust RefCount code (removing
   lock()/unlock() and using the Lock counter directly).  This
   approach has its limitations because, in general, it would be rather
   difficult (or impossible) to fix all code blocks that Coverity
   stumbles upon. Moreover, it sounds a bad practice to overcome
   problems of an external tool by code modifications.

2. Adjust Coverity model to suppress these false positives.
   Experiments showed that modelling both RefCount::reference() and
   dereference() does the trick.  This is a standard/documented [^1] way
   to address Coverity false positives. The potential danger is that we
   can end up suppressing not only false positives, but some legitimate
   double free bugs.  However, this should not matter because the tests
   showed that Coverity is unable to detect genuine double free
   RefCount bugs.  This may change in the future, of course, if/when
   Coverity becomes smarter.

[^1]: https://scan5.scan.coverity.com/doc/en/cov_checker_ref.html
