### PR TITLE
Fix bugs found in v6-v7 branching

### DIFF
--- a/release/mk-release-series.sh
+++ b/release/mk-release-series.sh
@@ -52,7 +52,7 @@ fi
     git add configure.ac
 
   echo " .. add Release Notes ..."
-  sed -e s/@SQUID_RELEASE_OLD@/$OLDVER/g <doc/release-notes/template.sgml >doc/release-notes/release-${NEWVER}.sgml.in &&
+  cp doc/release-notes/template.sgml doc/release-notes/release-${NEWVER}.sgml.in &&
     git add doc/release-notes/release-${NEWVER}.sgml.in
 
   if `git diff HEAD` ; then

--- a/release/mk-release-series.sh
+++ b/release/mk-release-series.sh
@@ -17,8 +17,9 @@ if ! test -f $vcsdir/squid-$OLDVER/.BASE ; then
 else
   echo " . Promoting Squid-$OLDVER to Beta Release ..."
   cd squid-$OLDVER
-  git checkout github/v$OLDVER || exit 1
+  git checkout github/`cat .BASE` || exit 1
   git push -u origin v$OLDVER
+  git push -u github v$OLDVER
   rm .BASE
 fi
 
@@ -31,7 +32,7 @@ else
   cd $vcsdir
   git clone git@github.com:squidadm/squid.git squid-$NEWVER
   cd squid-$NEWVER
-  git remote add github https://github.com/squid-cache/squid.git
+  git remote add github git@github.com:squid-cache/squid.git
   echo "master" >.BASE
   ln -s $vcsdir/gitignore $vcsdir/squid-$NEWVER/.git/info/exclude
 
@@ -46,17 +47,13 @@ fi
   cd $vcsdir/squid-$NEWVER
   echo " .. update configure.ac ..."
   git checkout v${NEWVER}-maintenance
-  sed -e 's/${OLDVER}.0.0-VCS/${NEWVER}.0.0-VCS/' <configure.ac >configure.ac.2 &&
+  sed -e s/${OLDVER}.0.0-VCS/${NEWVER}.0.0-VCS/ <configure.ac >configure.ac.2 &&
     mv configure.ac.2 configure.ac &&
     git add configure.ac
 
   echo " .. add Release Notes ..."
-  cp doc/release-notes/release-N.template doc/release-notes/release-${NEWVER}.sgml &&
-    git add doc/release-notes/release-${NEWVER}.sgml
-  echo " .. auto-build new Release Notes ..."
-  sed -e 's/DOC= release-$OLDVER/DOC= release-$NEWVER/' <doc/release-notes/Makefile.am >notes.tmp &&
-    mv notes.tmp doc/release-notes/Makefile.am &&
-    git add doc/release-notes/Makefile.am &&
+  sed -e s/@SQUID_RELEASE_OLD@/$OLDVER/g <doc/release-notes/template.sgml >doc/release-notes/release-${NEWVER}.sgml.in &&
+    git add doc/release-notes/release-${NEWVER}.sgml.in
 
   if `git diff HEAD` ; then
     git commit -m "Branch ${NEWVER}.0.0"


### PR DESCRIPTION
* OLDVER branch does not exist when .BASE exists
* https:// repository access is read-only
* sed argument quoting overrides shell variable expansion

Also, release notes auto-create to support changes from
 https://github.com/squid-cache/squid/pull/1245
and
 https://github.com/squid-cache/squid/pull/1264