### PR TITLE
mk-release-snapshot: use jenkins artifacts

### DIFF
--- a/release/mk-release-snapshots.sh
+++ b/release/mk-release-snapshots.sh
@@ -21,12 +21,18 @@ get_artifacts() {
 	local job=$1
 	local outdir=$2
 	local artifactsUrl="https://$SQUID_BUILD_SERVER/job/${job}/lastSuccessfulBuild/artifact/artifacts/*zip*/artifacts.zip"
-	if ! wget --quiet --ca-cert=/etc/ssl/certs/ISRG_Root_X1.pem "$artifactsUrl"; then
+	rm artifacts.zip 2>&1 >/dev/null
+	if ! wget --quiet --ca-cert=/etc/ssl/certs/ISRG_Root_X1.pem "$artifactsUrl" ; then
 		echo "could not download artifacts from $artifactsUrl"
 		return 1
 	fi
-	unzip -qq artifacts.zip
-	if [ ! -d artifacts ]; then
+ 	rmdir -f artifacts 2>&1 >/dev/null
+	if ! unzip -qq artifacts.zip ; then
+		echo "could not extract files from ${job}:artifacts.zip"
+		rmdir -f artifacts 2>&1 >/dev/null
+  		return 1
+ 	fi
+	if ! test -d artifacts ; then
 		echo "${job}:artifacts.zip does not contain a subdirectory"
 		rm -d `unzip -Z1 artifacts.zip`
 		rm -f artifacts.zip

--- a/release/mk-release-snapshots.sh
+++ b/release/mk-release-snapshots.sh
@@ -26,7 +26,13 @@ get_artifacts() {
 		echo "could not download artifacts from $artifactsUrl"
 		return 1
 	fi
- 	rmdir -f artifacts 2>&1 >/dev/null
+ 	rm -r -f artifacts > /dev/null 2>&1
+ 	if test -e artifacts
+ 	then
+ 	    rm -r -f artifacts # now show the previously hidden error
+ 	    echo "Failed to cleanup stale `pwd`/artifacts" 1>&2
+ 	    return 1
+ 	fi
 	if ! unzip -qq artifacts.zip ; then
 		echo "could not extract files from ${job}:artifacts.zip"
 		rmdir -f artifacts 2>&1 >/dev/null

--- a/release/mk-release-snapshots.sh
+++ b/release/mk-release-snapshots.sh
@@ -38,7 +38,7 @@ get_artifacts() {
   		return 1
  	fi
 	if ! test -d artifacts ; then
-		echo "${job}:artifacts.zip does not contain a subdirectory" 1>&2
+		echo "${job}:artifacts.zip does not contain an 'artifacts/' directory" 1>&2
 		rm -d `unzip -Z1 artifacts.zip`
 		rm -f artifacts.zip
 		return 1

--- a/release/mk-release-snapshots.sh
+++ b/release/mk-release-snapshots.sh
@@ -28,7 +28,7 @@ get_artifacts() {
 	fi
  	rm -r artifacts >/dev/null 2>&1
  	if test -e artifacts ; then
- 	    rm -rf artifacts
+ 	    rm -r artifacts
  	    echo "Failed to cleanup stale `pwd`/artifacts" 1>&2
  	    return 1
  	fi

--- a/release/mk-release-snapshots.sh
+++ b/release/mk-release-snapshots.sh
@@ -21,32 +21,31 @@ get_artifacts() {
 	local job=$1
 	local outdir=$2
 	local artifactsUrl="https://$SQUID_BUILD_SERVER/job/${job}/lastSuccessfulBuild/artifact/artifacts/*zip*/artifacts.zip"
-	rm artifacts.zip 2>&1 >/dev/null
+	rm -f artifacts.zip >/dev/null 2>&1
 	if ! wget --quiet --ca-cert=/etc/ssl/certs/ISRG_Root_X1.pem "$artifactsUrl" ; then
-		echo "could not download artifacts from $artifactsUrl"
+		echo "Failed to download artifacts from $artifactsUrl" 1>&2
 		return 1
 	fi
- 	rm -r -f artifacts > /dev/null 2>&1
- 	if test -e artifacts
- 	then
- 	    rm -r -f artifacts # now show the previously hidden error
+ 	rm -r artifacts >/dev/null 2>&1
+ 	if test -e artifacts ; then
+ 	    rm -rf artifacts
  	    echo "Failed to cleanup stale `pwd`/artifacts" 1>&2
  	    return 1
  	fi
 	if ! unzip -qq artifacts.zip ; then
-		echo "could not extract files from ${job}:artifacts.zip"
-		rmdir -f artifacts 2>&1 >/dev/null
+		echo "Failed to extract files from ${job}:artifacts.zip" 1>&2
+		rm -rf artifacts >/dev/null 2>&1
   		return 1
  	fi
 	if ! test -d artifacts ; then
-		echo "${job}:artifacts.zip does not contain a subdirectory"
+		echo "${job}:artifacts.zip does not contain a subdirectory" 1>&2
 		rm -d `unzip -Z1 artifacts.zip`
 		rm -f artifacts.zip
 		return 1
 	fi
-	mv artifacts/* $outdir
-	rmdir artifacts
 	rm artifacts.zip
+	mv artifacts/* $outdir
+	rm -rf artifacts
 	return 0
 }
 

--- a/release/mk-release-snapshots.sh
+++ b/release/mk-release-snapshots.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Publish the latest development release (a.k.a. daily snapshot)
 #

--- a/release/mk-release-snapshots.sh
+++ b/release/mk-release-snapshots.sh
@@ -44,7 +44,7 @@ get_artifacts() {
 		return 1
 	fi
 	rm artifacts.zip
-	mv artifacts/* $outdir
+	mv artifacts/* $outdir || ( rm -rf artifacts ; return 1 )
 	rm -rf artifacts
 	return 0
 }

--- a/release/mk-release-snapshots.sh
+++ b/release/mk-release-snapshots.sh
@@ -32,7 +32,7 @@ get_artifacts() {
  	    echo "Failed to cleanup stale `pwd`/artifacts" 1>&2
  	    return 1
  	fi
-	if ! unzip -qq artifacts.zip ; then
+	if ! unzip -u -o -qq artifacts.zip ; then
 		echo "Failed to extract files from ${job}:artifacts.zip" 1>&2
 		rm -rf artifacts >/dev/null 2>&1
   		return 1

--- a/release/mk-release-snapshots.sh
+++ b/release/mk-release-snapshots.sh
@@ -21,8 +21,7 @@ get_artifacts() {
 	local job=$1
 	local outdir=$2
 	local artifactsUrl="https://$SQUID_BUILD_SERVER/job/${job}/lastSuccessfulBuild/artifact/artifacts/*zip*/artifacts.zip"
-	wget --quiet --ca-cert=/etc/ssl/certs/ISRG_Root_X1.pem "$artifactsUrl"
-	if [ ! -e artifacts.zip ] ; then
+	if ! wget --quiet --ca-cert=/etc/ssl/certs/ISRG_Root_X1.pem "$artifactsUrl"; then
 		echo "could not download artifacts from $artifactsUrl"
 		return 1
 	fi
@@ -38,7 +37,8 @@ get_artifacts() {
 	rm artifacts.zip
 	return 0
 }
-cd /var/tmp
+
+cd /var/tmp || exit $?
 
 ver=$SQUID_RELEASE
 get_artifacts website-tarballs-head $SQUID_WWW_PATH/content/Versions/v$ver/

--- a/release/mk-release-snapshots.sh
+++ b/release/mk-release-snapshots.sh
@@ -21,7 +21,7 @@ get_artifacts() {
 	local job=$1
 	local outdir=$2
 	local artifactsUrl="https://$SQUID_BUILD_SERVER/job/${job}/lastSuccessfulBuild/artifact/artifacts/*zip*/artifacts.zip"
-	wget --quiet "$artifactsUrl"
+	wget --quiet --ca-cert=/etc/ssl/certs/ISRG_Root_X1.pem "$artifactsUrl"
 	if [ ! -e artifacts.zip ] ; then
 		echo "could not download artifacts from $artifactsUrl"
 		return 1
@@ -29,7 +29,9 @@ get_artifacts() {
 	unzip -qq artifacts.zip
 	if [ ! -d artifacts ]; then
 		echo "${job}:artifacts.zip does not contain a subdirectory"
-		return 1;
+		rm -d `unzip -Z1 artifacts.zip`
+		rm -f artifacts.zip
+		return 1
 	fi
 	mv artifacts/* $outdir
 	rmdir artifacts


### PR DESCRIPTION
The snapshots workflow was too complicated and rotten.
This new workflow is much simpler and more reliable.