### PR TITLE
Fix maintenance PR creation

### DIFF
--- a/maintenance/code-maintenance.sh
+++ b/maintenance/code-maintenance.sh
@@ -49,7 +49,7 @@ runMaintenanceScript ()
     git push $beQuiet -f --set-upstream origin +$branch 2>&1 >/dev/null || exit 1
     gitCleanWorkspace
 
-    if test `git diff $beQuiet $forkPoint $branch 2>/dev/null | wc -l` -ne 0 ; then
+    if test `git diff --shortstat $forkPoint $branch 2>/dev/null | wc -l` -ne 0 ; then
       # skip if there is an existing PR already open awaiting merge
       prlist=`gh pr list -L 1 --repo squid-cache/squid --head $branch`
       if ! test -z "$prlist" ; then

--- a/maintenance/code-maintenance.sh
+++ b/maintenance/code-maintenance.sh
@@ -51,8 +51,8 @@ runMaintenanceScript ()
 
     if test `git diff --shortstat $forkPoint $branch 2>/dev/null | wc -l` -ne 0 ; then
       # skip if there is an existing PR already open awaiting merge
-      prlist=`gh pr list -L 1 --repo squid-cache/squid --head $branch`
-      if ! test -z "$prlist" ; then
+      prlist=`gh pr list -L 1 --repo squid-cache/squid --head $branch | grep -v "no pull requests match"`
+      if test -z "$prlist" ; then
         gh pr create --repo squid-cache/squid --base $forkPoint --fill
       fi
       # wait for this set of changes to complete before submittng more


### PR DESCRIPTION
The `--quiet` parameter removes patch from `git diff`
output rendering the line count useless as a trigger
to commit changes.

Instead use `--shortstat` which produces nothing when
there is no difference the the given branches, and a
line of statistics if there are differences.

Recent `gh` tool produce a message when no PRs exist.
Causing this script to wrongly decide that no PR is needed.
Check for that output and revert the line count test to check
for that empty case at trigger.