### PR TITLE
Fix multiple comments on label change failure

### DIFF
--- a/maintenance/code-backports.sh
+++ b/maintenance/code-backports.sh
@@ -62,7 +62,7 @@ if test "$prlist" -ne 0; then
         echo "$msg" | grep -E "^error:"
         unlabel=`echo "$msg" | grep -E "The.previous.cherry-pick.is.now.empty"`
         if ! test -z "$unlabel" ; then
-            gh pr edit --repo squid-cache/squid $prnum --remove-label backport-to-v$version
+            gh pr edit --repo squid-cache/squid $prnum --remove-label backport-to-v$version &&
             gh pr comment --repo squid-cache/squid $prnum --body "queued for backport to v$version"
         fi
       fi


### PR DESCRIPTION
Only add comments when the labels actually changed.
The GH tool still needs to be updated to restore proper
behaviour.